### PR TITLE
fix: cve sum

### DIFF
--- a/trivy.jsonnet
+++ b/trivy.jsonnet
@@ -236,7 +236,7 @@ dashboard.new(
     ''
   ).addTarget(
     prometheus.target(
-      'max(trivy_image_vulnerabilities{}) by (image_registry, image_repository, image_tag)',
+      'sum(trivy_image_vulnerabilities{}) by (image_registry, image_repository, image_tag)',
       datasource='prometheus',
       format='table',
       instant=true,


### PR DESCRIPTION
TOTAL kolonnen i trivy dasboard viste tidligere ikke riktig tall. Den skal vise `sum`, ikke `max` :smile: 

Endringen kan verifiseres ved å sjekke ut `trivy` lenken i kommentaren nedenfor v